### PR TITLE
57533 - add new action for sending changelog

### DIFF
--- a/send_slack_message_changelog/README.md
+++ b/send_slack_message_changelog/README.md
@@ -1,0 +1,63 @@
+#Composite action to send changelog
+
+This action is used to send changelog with a descriptive header message to a given Slack channel.
+
+## Usage
+
+Inputs:
+- `message` - short explanatory message to include before changelog in the Slack message
+- `raw-changelog` - JSON generated from `tp_changelog` action
+- `slack-webhook-url:` - webhook of Slack channel where changelog message should be sent
+
+## Example
+
+With inputs:
+- `message`: `Hi QAs, please test this:`
+- `slack-webhook-url`: `<webhook url pointing to QA slack channel>`
+- `raw-changelog`: 
+```
+{
+  "userStories": [
+    {
+      "id": 321,
+      "title": "Support hotfix builds in backend repositories",
+      "state": "Ready For Testing",
+      "url": "https://auroratarget.tpondemand.com/entity/321",
+      "tasks": [
+        {
+          "id": 123,
+          "title": "BE - create automatic pull request from uat->dev",
+          "state": "Done",
+          "usId": 321,
+          "url": "https://auroratarget.tpondemand.com/entity/123",
+          "commit": {
+            "commit": "123 - create workflow for syncing uat with dev after hotfix (#2188)",
+            "author": "Cool person"
+          }
+        }
+      ]
+    }
+  ],
+  "unassigned": [
+    {
+      "commit": "Awesome feature (#2186)",
+      "author": "Awesome person"
+    }
+  ]
+}
+```
+
+Message sent to QA Slack channel will look something like this:
+
+```
+Hi QAs, please test this:
+
+:memo: User stories and tasks:
+1. #321 Support hotfix builds in backend repositories (Ready For Testing)
+1.1. #123 BE - create automatic pull request from uat->dev (Done)
+
+:question: Unassigned:
+1. Awesome feature (#2186) by Awesome person
+```
+
+

--- a/send_slack_message_changelog/action.yml
+++ b/send_slack_message_changelog/action.yml
@@ -1,0 +1,47 @@
+name: Send changelog to Slack
+description: Builds Slack message from raw changelog JSON and sends to Slack
+
+inputs:
+  message:
+    description: Message to include before the changelog
+    required: true
+  raw-changelog:
+    description: Downloaded changelog JSON
+    required: true
+  slack-webhook-url:
+    description: URL of the Slack webhook to send the notification
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Generate changelog block section
+      if: ${{ always() }}
+      id: prep_slack_changelog
+      uses: elderstudios/actions/generate_changelog_slack_sections@v2
+      with:
+        CHANGELOG_JSON: ${{inputs.raw-changelog}}
+    - name: Prepare env variables
+      shell: bash
+      run: |
+        echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
+        echo '${{steps.prep_slack_changelog.outputs.SLACK_CHANGELOG_SECTIONS}}' | jq -r '.' | head -n -1 | tail -n +2 >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+        echo HEADER_MESSAGE="${{inputs.message}}" >> $GITHUB_ENV
+    - name: Checkout to actions repository
+      uses: actions/checkout@v2
+      with:
+        repository: elderstudios/actions
+        path: actions-repo
+    - name: Substitute variables in the slack message template
+      uses: danielr1996/envsubst-action@1.1.0
+      with:
+        input: ./actions-repo/send_slack_message_changelog/changelog_message.tpl.json
+        output: output.json
+    - name: Send Slack notification
+      uses: slackapi/slack-github-action@v1.21.0
+      with:
+        payload-file-path: output.json
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/send_slack_message_changelog/changelog_message.tpl.json
+++ b/send_slack_message_changelog/changelog_message.tpl.json
@@ -1,0 +1,12 @@
+{
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "$HEADER_MESSAGE"
+      }
+    },
+    $CHANGELOG
+  ]
+}


### PR DESCRIPTION
When this is merged, `extra-sections` stuff can be removed from `send_slack_message_deployment` action and all the workflows that need to send changelog can be replaced to use this action.